### PR TITLE
FIX count wall time instead of CPU time

### DIFF
--- a/src/components/Pomodoro.js
+++ b/src/components/Pomodoro.js
@@ -224,7 +224,10 @@ const Pomodoro = ({ name }) => {
 							<ActionIcon
 								color="red"
 								variant="light"
-								onClick={() => setIsActive(false)}
+								onClick={() => {
+									setIsActive(false)
+									setPreviousTimestamp(null)
+								}}
 								aria-label="Pause pomodoro"
 							>
 								<IconPlayerPause size={18} />


### PR DESCRIPTION
Intervall only accounts for CPU time
passed, not actual wall time passed
resulting in the timer going slower
than actual wall time.

CPU time vs Wall time
When a browser tab or window is off-screen
or in a tab that isn't focused, the scheduler
doesn't execute the JS engine every
tick/second. Instead, the process is scheduled
to run in less frequent intervals. This means
that one can't assume that the interval timer
will execute once every wall time second, but
rather once every "JS engine active" second.
Since the countdown should count wall time,
we need to calculate a timestamp based delta
for when the function last ran.